### PR TITLE
Control the location of the Keycloak archive

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,33 @@ command line as an extra-var:
 
   `ansible-playbook ... --extra-vars "force=yes"`
 
+Controlling the location of the Keycloak archive
+------------------------------------------------
+
+By default the Keycloak archive will be downloaded to the local system
+where the playbook is being run from. It will reside in the directory
+specified by the variable `keycloak_local_download_dest`. When the
+archive is extracted on the target system the archive will be read on
+the local system and the files created on the destination target. This
+behavior has the advantage of downloading the archive only once and
+not storing the archive on the target but it incurs a network penalty
+of transferring the archive contents again for every target during the
+extraction process. If you have a slow upload network link on the host
+running the playbook the non-local extraction may be untenable.
+
+Alternately you have the option to download the archive directly to
+the target and extract the archive on the target, this is controlled
+by the `keycloak_archive_on_target` variable. This has the advantage
+of transferring the archive data only once. The archive extraction
+will be fast because there is no network traffic during the extraction
+because all data is local to the target. However it will leave the
+archive on the target after extraction.
+
+To change the location of the archive on the command line add this
+argument to your playbook command line:
+
+  `-e "{keycloak_archive_on_target: True}"`
+  
 Variables
 ---------
 You can choose what version of Keycloak to install by setting the following

--- a/roles/keycloak/defaults/main.yml
+++ b/roles/keycloak/defaults/main.yml
@@ -16,3 +16,6 @@ keycloak_bind_address: 0.0.0.0
 keycloak_http_port: 8080
 keycloak_https_port: 8443
 keycloak_admin_user: admin
+
+# Optional Behavior
+keycloak_archive_on_target: false

--- a/roles/keycloak/tasks/main.yml
+++ b/roles/keycloak/tasks/main.yml
@@ -6,12 +6,6 @@
     dest: "{{ keycloak_local_download_dest }}"
     state: directory
 
-- name: download Keycloak locally
-  local_action:
-    module: get_url
-    url: "{{ keycloak_url }}"
-    dest: "{{ keycloak_local_download_dest }}/{{ keycloak_archive }}"
-
 - name: install dependencies
   yum:
     name: "{{ packages }}"
@@ -64,14 +58,40 @@
     become: yes
   when: existing_deploy.stat.exists == True
 
-- name: extract Keycloak archive
-  unarchive:
-    src: "{{ keycloak_local_download_dest }}/{{ keycloak_url | basename }}"
-    dest: "{{ keycloak_dest }}"
-    creates: "{{ keycloak_jboss_home }}"
-    owner: "{{ keycloak_service_user }}"
-    group: "{{ keycloak_service_group }}"
+- block:
+  - name: download Keycloak archive to target
+    get_url:
+      url: "{{ keycloak_url }}"
+      dest: "{{ keycloak_dest }}"
+      owner: "{{ keycloak_service_user }}"
+      group: "{{ keycloak_service_group }}"
+  - name: extract Keycloak archive on target
+    unarchive:
+      remote_src: yes
+      src: "{{ keycloak_dest }}/{{ keycloak_url | basename }}"
+      dest: "{{ keycloak_dest }}"
+      creates: "{{ keycloak_jboss_home }}"
+      owner: "{{ keycloak_service_user }}"
+      group: "{{ keycloak_service_group }}"
   become: yes
+  when: keycloak_archive_on_target
+
+- block:
+  - name: download Keycloak archive to local
+    local_action:
+      module: get_url
+      url: "{{ keycloak_url }}"
+      dest: "{{ keycloak_local_download_dest }}/{{ keycloak_archive }}"
+  - name: extract Keycloak archive on local
+    unarchive:
+      remote_src: no
+      src: "{{ keycloak_local_download_dest }}/{{ keycloak_url | basename }}"
+      dest: "{{ keycloak_dest }}"
+      creates: "{{ keycloak_jboss_home }}"
+      owner: "{{ keycloak_service_user }}"
+      group: "{{ keycloak_service_group }}"
+  become: yes
+  when: not keycloak_archive_on_target
 
 - name: create Keycloak admin user
   command:


### PR DESCRIPTION
In different scenarios there are advantages to downloading the
Keycloak achive ether to the local system where the playbook is being
run or downloading it to the target system. This patch introduces the
variabele `keycloak_archive_on_target` to control the behavior.

Signed-off-by: John Dennis <jdennis@redhat.com>