### PR TITLE
Ci tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,39 @@ provided:
 See `roles/keycloak/defaults/main.yml` for a list of other variable
 defaults that one may want to override.
 
+Testing
+-------
+In-tree tests are provided that use molecule to test the role against docker containers.
+These tests are designed to be used by CI, but they can also be run locally to test it
+out while developing.  This is best done by installing molecule in a virtualenv:
+
+  `$ virtualenv .venv`
+  `$ source .venv/bin/activate`
+  `$ pip install molecule docker`
+
+It is required to run the tests as a user who is authorized to run the 'docker' command
+without using sudo.  This is typically accomplished by adding your user to the 'docker'
+group on your system.
+
+Additionally, there is a challenge around python-libselinux on platforms that use SELinux.
+If you are using a virtualenv, you need to make sure that the selinux python module is
+available in the virtualenv.  Even if it is installed on your ansible controller host
+and the target host, some of the tasks that are delegated to the locahost will use the
+virtualenv.  The selinux module can't be installed via pip.  A workaround for this is
+to copy the entire `selinux` directory from your system site-packages location into
+the virtualenv site-packages.  You also need to copy the `_selinux.so` file from
+site-locations as well.
+
+Once your virtualenv is properly set up, the tests can be run with these commands:
+
+  `$ cd roles/keycloak`
+  `$ molecule test`
+
+By default, the test target will be the latest `centos` image from Docker Hub.  You
+can test against a different image/tag like so:
+
+  `$ MOLECULE_DISTRO="fedora:28" molecule test`
+
 TODO
 ----
 - Add example playbook that uses ansible-freeipa to create keycloak service and get cert

--- a/roles/keycloak/defaults/main.yml
+++ b/roles/keycloak/defaults/main.yml
@@ -2,12 +2,14 @@
 # Version and download settings
 keycloak_version: 4.8.2.Final
 keycloak_archive: keycloak-{{ keycloak_version }}.zip
-keycloak_url: https://downloads.jboss.org/keycloak/{{ keycloak_version }}/{{ keycloak_archive }}
+keycloak_url: https://downloads.jboss.org/keycloak/{{
+              keycloak_version }}/{{ keycloak_archive }}
 keycloak_local_download_dest: ~/keycloak_download
 
 # Install location and service settings
 keycloak_dest: /opt/keycloak
 keycloak_jboss_home: "{{ keycloak_dest }}/keycloak-{{ keycloak_version }}"
+keycloak_config_dir: "{{ keycloak_jboss_home }}/standalone/configuration"
 keycloak_service_user: keycloak
 keycloak_service_group: keycloak
 

--- a/roles/keycloak/files/py3test.py
+++ b/roles/keycloak/files/py3test.py
@@ -1,0 +1,3 @@
+#!/usr/bin/python3
+
+import sys

--- a/roles/keycloak/molecule/default/Dockerfile.j2
+++ b/roles/keycloak/molecule/default/Dockerfile.j2
@@ -1,0 +1,14 @@
+# Molecule managed
+
+{% if item.registry is defined %}
+FROM {{ item.registry.url }}/{{ item.image }}
+{% else %}
+FROM {{ item.image }}
+{% endif %}
+
+RUN if [ $(command -v apt-get) ]; then apt-get update && apt-get install -y python sudo bash ca-certificates && apt-get clean; \
+    elif [ $(command -v dnf) ]; then dnf makecache && dnf --assumeyes install python sudo python-devel python2-dnf bash && dnf clean all; \
+    elif [ $(command -v yum) ]; then yum makecache fast && yum install -y python sudo yum-plugin-ovl bash && sed -i 's/plugins=0/plugins=1/g' /etc/yum.conf && yum clean all; \
+    elif [ $(command -v zypper) ]; then zypper refresh && zypper install -y python sudo bash python-xml && zypper clean -a; \
+    elif [ $(command -v apk) ]; then apk update && apk add --no-cache python sudo bash ca-certificates; \
+    elif [ $(command -v xbps-install) ]; then xbps-install -Syu && xbps-install -y python sudo bash ca-certificates && xbps-remove -O; fi

--- a/roles/keycloak/molecule/default/INSTALL.rst
+++ b/roles/keycloak/molecule/default/INSTALL.rst
@@ -1,0 +1,16 @@
+*******
+Docker driver installation guide
+*******
+
+Requirements
+============
+
+* General molecule dependencies (see https://molecule.readthedocs.io/en/latest/installation.html)
+* Docker Engine
+* docker-py
+* docker
+
+Install
+=======
+
+    $ sudo pip install docker-py

--- a/roles/keycloak/molecule/default/molecule.yml
+++ b/roles/keycloak/molecule/default/molecule.yml
@@ -1,0 +1,41 @@
+---
+dependency:
+  name: galaxy
+driver:
+  name: docker
+lint:
+  name: yamllint
+  options:
+    config-file: molecule/default/yaml-lint.yml
+platforms:
+  - name: instance
+    image: ${MOLECULE_DISTRO:-"centos:7"}
+    command: /sbin/init
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:ro
+    privileged: true
+provisioner:
+  name: ansible
+  lint:
+    name: ansible-lint
+scenario:
+  name: default
+  # This role is currently not idempotent, as we fail when a deployment
+  # aready exists.  We skip this test for now, though it would be a good idea
+  # to make the role idempotent.
+  test_sequence:
+    - lint
+    - destroy
+    - dependency
+    - syntax
+    - create
+    - prepare
+    - converge
+    # - idempotence
+    - side_effect
+    - verify
+    - destroy
+verifier:
+  name: testinfra
+  lint:
+    name: flake8

--- a/roles/keycloak/molecule/default/playbook.yml
+++ b/roles/keycloak/molecule/default/playbook.yml
@@ -1,0 +1,7 @@
+---
+- name: Converge
+  hosts: all
+  roles:
+    - role: keycloak
+  vars:
+    keycloak_admin_password: password

--- a/roles/keycloak/molecule/default/tests/test_default.py
+++ b/roles/keycloak/molecule/default/tests/test_default.py
@@ -1,0 +1,14 @@
+import os
+
+import testinfra.utils.ansible_runner
+
+testinfra_hosts = testinfra.utils.ansible_runner.AnsibleRunner(
+    os.environ['MOLECULE_INVENTORY_FILE']).get_hosts('all')
+
+
+def test_hosts_file(host):
+    f = host.file('/etc/hosts')
+
+    assert f.exists
+    assert f.user == 'root'
+    assert f.group == 'root'

--- a/roles/keycloak/molecule/default/yaml-lint.yml
+++ b/roles/keycloak/molecule/default/yaml-lint.yml
@@ -1,0 +1,6 @@
+---
+extends: default
+rules:
+  line-length:
+    max: 80
+  truthy: disable

--- a/roles/keycloak/tasks/main.yml
+++ b/roles/keycloak/tasks/main.yml
@@ -11,9 +11,9 @@
     name: "{{ packages }}"
   vars:
     packages:
-    - firewalld
-    - java-openjdk
-    - unzip
+      - firewalld
+      - java-openjdk
+      - unzip
   become: yes
 
 - name: create Keycloak service user/group
@@ -43,54 +43,59 @@
 # may have been made within Keycloak's database that would be lost.
 # A force variable can be set to overwrite the existing deployment.
 - block:
-  - fail:
-      msg: "Keycloak deployment already exists at {{ keycloak_jboss_home }} (force=yes to overwrite)"
-    when: (force is undefined) or
-          (force != "yes")
-  - systemd:
-      name: keycloak
-      state: stopped
-    become: yes
-    ignore_errors: yes
-  - file:
-      path: "{{ keycloak_jboss_home }}"
-      state: absent
-    become: yes
+    - name: check if we should force overwrite an existing deployment
+      fail:
+        msg: >-
+          Keycloak deployment already exists at {{ keycloak_jboss_home }}
+          (force=yes to overwrite)
+      when: (force is undefined) or
+            (force != "yes")
+    - name: stop the old keycloak service
+      systemd:
+        name: keycloak
+        state: stopped
+      become: yes
+      ignore_errors: yes
+    - name: remote the old Keycloak deployment
+      file:
+        path: "{{ keycloak_jboss_home }}"
+        state: absent
+      become: yes
   when: existing_deploy.stat.exists == True
 
 - block:
-  - name: download Keycloak archive to target
-    get_url:
-      url: "{{ keycloak_url }}"
-      dest: "{{ keycloak_dest }}"
-      owner: "{{ keycloak_service_user }}"
-      group: "{{ keycloak_service_group }}"
-  - name: extract Keycloak archive on target
-    unarchive:
-      remote_src: yes
-      src: "{{ keycloak_dest }}/{{ keycloak_url | basename }}"
-      dest: "{{ keycloak_dest }}"
-      creates: "{{ keycloak_jboss_home }}"
-      owner: "{{ keycloak_service_user }}"
-      group: "{{ keycloak_service_group }}"
+    - name: download Keycloak archive to target
+      get_url:
+        url: "{{ keycloak_url }}"
+        dest: "{{ keycloak_dest }}"
+        owner: "{{ keycloak_service_user }}"
+        group: "{{ keycloak_service_group }}"
+    - name: extract Keycloak archive on target
+      unarchive:
+        remote_src: yes
+        src: "{{ keycloak_dest }}/{{ keycloak_url | basename }}"
+        dest: "{{ keycloak_dest }}"
+        creates: "{{ keycloak_jboss_home }}"
+        owner: "{{ keycloak_service_user }}"
+        group: "{{ keycloak_service_group }}"
   become: yes
   when: keycloak_archive_on_target
 
 - block:
-  - name: download Keycloak archive to local
-    local_action:
-      module: get_url
-      url: "{{ keycloak_url }}"
-      dest: "{{ keycloak_local_download_dest }}/{{ keycloak_archive }}"
-  - name: extract Keycloak archive on local
-    unarchive:
-      remote_src: no
-      src: "{{ keycloak_local_download_dest }}/{{ keycloak_url | basename }}"
-      dest: "{{ keycloak_dest }}"
-      creates: "{{ keycloak_jboss_home }}"
-      owner: "{{ keycloak_service_user }}"
-      group: "{{ keycloak_service_group }}"
-  become: yes
+    - name: download Keycloak archive to local
+      local_action:
+        module: get_url
+        url: "{{ keycloak_url }}"
+        dest: "{{ keycloak_local_download_dest }}/{{ keycloak_archive }}"
+    - name: extract Keycloak archive on local
+      unarchive:
+        remote_src: no
+        src: "{{ keycloak_local_download_dest }}/{{ keycloak_url | basename }}"
+        dest: "{{ keycloak_dest }}"
+        creates: "{{ keycloak_jboss_home }}"
+        owner: "{{ keycloak_service_user }}"
+        group: "{{ keycloak_service_group }}"
+      become: yes
   when: not keycloak_archive_on_target
 
 - name: create Keycloak admin user
@@ -101,20 +106,24 @@
       - -r master
       - -u {{ keycloak_admin_user }}
       - -p {{ keycloak_admin_password }}
-    creates: "{{ keycloak_jboss_home }}/standalone/configuration/keycloak-add-user.json"
+    creates: "{{ keycloak_config_dir }}/keycloak-add-user.json"
   become: yes
+  tags:
+    - skip_ansible_lint
 
-- name: import CA certificate into keystore
+- name: configure CA certificate
   block:
-  - copy:
-      src: "{{ keycloak_tls_ca_certificate }}"
-      dest: "{{ keycloak_jboss_home }}/standalone/configuration/ansible-keycloak-ca.pem"
-  - java_cert:
-      cert_alias: ansible-keycloak-ca
-      cert_path: "{{ keycloak_jboss_home }}/standalone/configuration/ansible-keycloak-ca.pem"
-      keystore_path: "{{ keycloak_jboss_home }}/standalone/configuration/keycloak.jks"
-      keystore_pass: "{{ keycloak_admin_password }}"
-      keystore_create: true
+    - name: copy CA certificate to target host
+      copy:
+        src: "{{ keycloak_tls_ca_certificate }}"
+        dest: "{{ keycloak_config_dir }}/ansible-keycloak-ca.pem"
+    - name: import the CA cert
+      java_cert:
+        cert_alias: ansible-keycloak-ca
+        cert_path: "{{ keycloak_config_dir }}/ansible-keycloak-ca.pem"
+        keystore_path: "{{ keycloak_config_dir }}/keycloak.jks"
+        keystore_pass: "{{ keycloak_admin_password }}"
+        keystore_create: true
   when: keycloak_tls_ca_certificate is defined
   become: yes
 
@@ -128,7 +137,8 @@
     action: export
     force: yes
     path: "{{ keycloak_local_download_dest }}/ansible-keycloak-server.p12"
-    passphrase: "{{ keycloak_tls_pkcs12_passphrase | default(keycloak_admin_password) }}"
+    passphrase: "{{ keycloak_tls_pkcs12_passphrase |
+                 default(keycloak_admin_password) }}"
     friendly_name: ansible-keycloak-server
     privatekey_path: "{{ keycloak_tls_key }}"
     certificate_path: "{{ keycloak_tls_cert }}"
@@ -137,20 +147,24 @@
     - keycloak_tls_key is defined
     - keycloak_tls_cert is defined
     - keycloak_tls_pkcs12 is not defined
- 
-- name: import pkcs12 bundle into keystore
+
+- name: configure keystore for server certificate
   block:
-  - copy:
-      src: "{{ keycloak_tls_pkcs12 | default(keycloak_local_download_dest + '/ansible-keycloak-server.p12') }}"
-      dest: "{{ keycloak_jboss_home }}/standalone/configuration/ansible-keycloak-server.p12"
-  - java_cert:
-      cert_alias: ansible-keycloak-server
-      keystore_path: "{{ keycloak_jboss_home }}/standalone/configuration/keycloak.jks"
-      keystore_pass: "{{ keycloak_admin_password }}"
-      keystore_create: true
-      pkcs12_path: "{{ keycloak_jboss_home }}/standalone/configuration/ansible-keycloak-server.p12"
-      pkcs12_password: "{{ keycloak_tls_pkcs12_passphrase | default(keycloak_admin_password) }}"
-      pkcs12_alias: ansible-keycloak-server
+    - name: copy pkcs12 bundle to target host
+      copy:
+        src: "{{ keycloak_tls_pkcs12 | default(keycloak_local_download_dest +
+              '/ansible-keycloak-server.p12') }}"
+        dest: "{{ keycloak_config_dir }}/ansible-keycloak-server.p12"
+    - name: import pkcs12 bundle into keystore
+      java_cert:
+        cert_alias: ansible-keycloak-server
+        keystore_path: "{{ keycloak_config_dir }}/keycloak.jks"
+        keystore_pass: "{{ keycloak_admin_password }}"
+        keystore_create: true
+        pkcs12_path: "{{ keycloak_config_dir }}/ansible-keycloak-server.p12"
+        pkcs12_password: "{{ keycloak_tls_pkcs12_passphrase |
+                          default(keycloak_admin_password) }}"
+        pkcs12_alias: ansible-keycloak-server
   when: (keycloak_tls_pkcs12 is defined) or
         (keycloak_generated_pkcs12_bundle is changed)
   become: yes
@@ -211,32 +225,34 @@
 # restart the keycloak service for our changes to take effect.
 - name: enable TLS in Keycloak server configuration file
   block:
-  - wait_for:
-      port: 9990
-  - command:
-    args:
-      argv:
-        - "{{ keycloak_jboss_home }}/bin/jboss-cli.sh"
-        - --connect
-        - --timeout=30000
-        - "/core-service=management/security-realm=UndertowRealm:add()"
-  - command:
-    args:
-      argv:
-        - "{{ keycloak_jboss_home }}/bin/jboss-cli.sh"
-        - --connect
-        - --timeout=30000
-        - "/core-service=management/security-realm=UndertowRealm/server-identity=ssl:add(keystore-path=keycloak.jks, keystore-relative-to=jboss.server.config.dir, keystore-password={{ keycloak_admin_password }})"
-  - command:
-    args:
-      argv:
-        - "{{ keycloak_jboss_home }}/bin/jboss-cli.sh"
-        - --connect
-        - --timeout=30000
-        - "/subsystem=undertow/server=default-server/https-listener=https:write-attribute(name=security-realm, value=UndertowRealm)"
-  - systemd:
-      name: keycloak
-      state: restarted
+    - name: wait for Keycloak management interface to be available
+      wait_for:
+        port: 9990
+    - name: create jboss-cli.sh command file
+      template:
+        src: standalone-tls-config.cli.j2
+        dest: "{{ keycloak_config_dir }}/standalone-tls-config.cli"
+        owner: root
+        group: root
+        mode: 0600
+    - name: apply keycloak TLS configuration
+      command:
+      args:
+        argv:
+          - "{{ keycloak_jboss_home }}/bin/jboss-cli.sh"
+          - --connect
+          - --timeout=30000
+          - --file={{ keycloak_config_dir }}/standalone-tls-config.cli
+      tags:
+        - skip_ansible_lint
+    - name: clean up jboss-cli-sh command file
+      file:
+        path: "{{ keycloak_config_dir }}/standalone-tls-config.cli"
+        state: absent
+    - name: restart keycloak service to pick up TLS configuration changes
+      systemd:
+        name: keycloak
+        state: restarted
   become: yes
   when: (keycloak_tls_pkcs12 is defined) or
         (keycloak_generated_pkcs12_bundle is changed)

--- a/roles/keycloak/tasks/main.yml
+++ b/roles/keycloak/tasks/main.yml
@@ -12,7 +12,7 @@
   vars:
     packages:
       - firewalld
-      - java-openjdk
+      - java-1.8.0-openjdk-headless
       - unzip
   become: yes
 

--- a/roles/keycloak/tasks/main.yml
+++ b/roles/keycloak/tasks/main.yml
@@ -1,5 +1,8 @@
 ---
 
+- name: set the python interpreter to use on the target
+  import_tasks: "{{role_path}}/tasks/python_2_3_test.yml"
+
 - name: create local download location
   local_action:
     module: file

--- a/roles/keycloak/tasks/main.yml
+++ b/roles/keycloak/tasks/main.yml
@@ -7,13 +7,12 @@
     state: directory
 
 - name: install dependencies
-  yum:
-    name: "{{ packages }}"
-  vars:
-    packages:
-      - firewalld
-      - java-1.8.0-openjdk-headless
-      - unzip
+  package:
+    name: "{{ item }}"
+  loop:
+    - firewalld
+    - java-1.8.0-openjdk-headless
+    - unzip
   become: yes
 
 - name: create Keycloak service user/group

--- a/roles/keycloak/tasks/python_2_3_test.yml
+++ b/roles/keycloak/tasks/python_2_3_test.yml
@@ -1,0 +1,17 @@
+---
+- block:
+  - name: Verify Python3 import
+    script: py3test.py
+    register: py3test
+    failed_when: False
+    changed_when: False
+
+  - name: Set python interpreter to 3
+    set_fact:
+      ansible_python_interpreter: "/usr/bin/python3"
+    when: py3test.rc == 0
+
+  - name: Set python interpreter to 2
+    set_fact:
+      ansible_python_interpreter: "/usr/bin/python2"
+    when: py3test.failed or py3test.rc != 0

--- a/roles/keycloak/templates/standalone-tls-config.cli.j2
+++ b/roles/keycloak/templates/standalone-tls-config.cli.j2
@@ -1,0 +1,19 @@
+# Add a new security realm
+/core-service=management/ \
+  security-realm=UndertowRealm \
+    :add()
+
+# Configure the security realm for our keystore
+/core-service=management/ \
+  security-realm=UndertowRealm/ \
+    server-identity=ssl \
+      :add(keystore-path=keycloak.jks, \
+           keystore-relative-to=jboss.server.config.dir, \
+           keystore-password={{ keycloak_admin_password }})
+
+#  Enable https listener for the new security realm
+/subsystem=undertow/ \
+  server=default-server/ \
+    https-listener=https \
+      :write-attribute(name=security-realm, \
+                       value=UndertowRealm)


### PR DESCRIPTION
This adds all of the patches necessary for basic working functional tests that pass on CentOS 7, Fedora 28, and Fedora 29.  It currently covers linting and the self-signed certificate deployment scenario.  We can build on this to provide more functional coverage, but it is a good start that we can use to add CI for the project.