### PR TITLE
Add Travis CI integration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,14 @@
+---
+sudo: required
+language: python
+services:
+  - docker
+env:
+  matrix:
+    - MOLECULE_DISTRO="centos:7"
+    - MOLECULE_DISTRO="fedora:28"
+    - MOLECULE_DISTRO="fedora:29"
+install:
+  - pip install molecule docker
+script:
+  - cd roles/keycloak && molecule test


### PR DESCRIPTION
This adds integration with travis CI that will execute our molecule
tests.  This executes the tests on CentOS 7, Fedora 28, and Fedora 29
in dicker containers on the VM that Travis provides.