### PR TITLE
Restrict CI for branch pushes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,3 +12,6 @@ install:
   - pip install molecule docker
 script:
   - cd roles/keycloak && molecule test
+branches:
+  only:
+  - master


### PR DESCRIPTION
This restricts pushes to branches to only trigger CI on master.  We
will run CI on all PRs still.  This prevents running the CI twice
when I push a topic branch that will be used for a PR.  If we start
using branches for other purposes, we can whitelist CI for those
branches as needed.