### PR TITLE
Use handlers to manage keycloak systemd service

### DIFF
--- a/roles/keycloak/handlers/main.yml
+++ b/roles/keycloak/handlers/main.yml
@@ -1,0 +1,13 @@
+---
+
+- name: reload systemd
+  systemd:
+    daemon_reload: yes
+  become: yes
+
+- name: restart keycloak
+  systemd:
+    name: keycloak
+    enabled: yes
+    state: restarted
+  become: yes

--- a/roles/keycloak/tasks/main.yml
+++ b/roles/keycloak/tasks/main.yml
@@ -197,6 +197,8 @@
     group: root
     mode: 0644
   become: yes
+  notify:
+    - restart keycloak
 
 - name: configure systemd unit file for keycloak service
   template:
@@ -206,18 +208,13 @@
     group: root
     mode: 0644
   become: yes
+  notify:
+    - reload systemd
+    - restart keycloak
 
-- name: reload systemd
-  systemd:
-    daemon_reload: yes
-  become: yes
-
-- name: enable and start the keycloak service
-  systemd:
-    name: keycloak
-    enabled: yes
-    state: started
-  become: yes
+# Force the handlers to run now, as keycloak needs to be running before
+# the next tasks are executed.
+- meta: flush_handlers
 
 # The jboss-cli.sh tool requires the management interface to be up,
 # so we wait until it is available.  The management interface comes
@@ -245,16 +242,14 @@
           - --connect
           - --timeout=30000
           - --file={{ keycloak_config_dir }}/standalone-tls-config.cli
+      notify:
+        - restart keycloak
       tags:
         - skip_ansible_lint
     - name: clean up jboss-cli-sh command file
       file:
         path: "{{ keycloak_config_dir }}/standalone-tls-config.cli"
         state: absent
-    - name: restart keycloak service to pick up TLS configuration changes
-      systemd:
-        name: keycloak
-        state: restarted
   become: yes
   when: (keycloak_tls_pkcs12 is defined) or
         (keycloak_generated_pkcs12_bundle is changed)


### PR DESCRIPTION
This pulls the tasks we use to reload systemd and restart the keycloak
service into handlers.