### PR TITLE
Modifications to support tripleo-quickstart-extras

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ database.  A force variable can be set to overwrite the existing deployment.
 This can be either be set as a variable in the playbook, or added on the
 command line as an extra-var:
 
-  `ansible-playbook ... --extra-vars "force=yes"`
+  `ansible-playbook ... --extra-vars "keycloak_force=yes"`
 
 Controlling the location of the Keycloak archive
 ------------------------------------------------
@@ -97,15 +97,34 @@ on, the following variables can be set:
 For TLS via PKCS12 bundle, the following additional variables must be
 provided:
 
-- `keycloak_tls_pkcs12` (local path to PKCS12 bundle)
+- `keycloak_tls_pkcs12` (path to PKCS12 bundle)
 - `keycloak_tls_pkcs12_passphrase` (use ansible-vault to protect)
 - `keycloak_tls_pkcs12_alias` (name of key/cert in `keycloak_tls_pkcs12`)
 
 For TLS via key/cert files, the following additional variables must be
 provided:
 
-- `keycloak_tls_cert` (local path to TLS server cert file)
-- `keycloak_tls_key` (local path to TLS server key file)
+- `keycloak_tls_cert` (path to TLS server cert file)
+- `keycloak_tls_key` (path to TLS server key file)
+
+**NOTE:** the source TLS files (`keycloak_tls_pkcs12`,
+`keycloak_tls_cert`, `keycloak_tls_key`) used to create the Keycloak
+keystore may reside either on the Ansible controller (i.e. local) or
+on the remote target host. By default the role assumes the source TLS
+files are local. If however the source TLS files are located on the
+remote target set the variable `keycloak_tls_files_on_target` to True.
+
+You can control timeout values with the following variables:
+
+`keycloak_startup_timeout`: Number of seconds to wait for Keycloak to
+start.
+
+`keycloak_jboss_config_connect_timeout`: Number of milliseconds to
+wait for jboss configuration utilityto connect to wildfly server.
+
+`keycloak_jboss_config_command_timeout`: Number of seconds to wait for
+jboss configuration utility to complete each command executed in
+configuration file
 
 See `roles/keycloak/defaults/main.yml` for a list of other variable
 defaults that one may want to override.

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,26 +1,48 @@
 ---
-# Version and download settings
+### Version and download settings
 keycloak_version: 4.8.2.Final
 keycloak_archive: keycloak-{{ keycloak_version }}.zip
 keycloak_url: https://downloads.jboss.org/keycloak/{{
               keycloak_version }}/{{ keycloak_archive }}
-keycloak_local_download_dest: ~/keycloak_download
+keycloak_local_download_dest: "{{ \"~/keycloak_download\" | expanduser }}"
 
-# Install location and service settings
+### Install location and service settings
 keycloak_dest: /opt/keycloak
 keycloak_jboss_home: "{{ keycloak_dest }}/keycloak-{{ keycloak_version }}"
 keycloak_config_dir: "{{ keycloak_jboss_home }}/standalone/configuration"
 keycloak_service_user: keycloak
 keycloak_service_group: keycloak
 
-# Keycloak configuration settings
+### Keycloak configuration settings
 keycloak_bind_address: 0.0.0.0
 keycloak_http_port: 8080
 keycloak_https_port: 8443
+keycloak_management_http_port: 9990
+keycloak_management_https_port: 9993
+
+
 keycloak_admin_user: admin
 
-# TLS
+### TLS
 keycloak_keystore_name: ansible-keycloak-server.p12
+keycloak_tls_files_on_target: false
 
-# Optional Behavior
+### Optional Behavior
+
+# If Keycloak is already installed remove it and re-install
+keycloak_force: false
+
+# Download Keycloak distribution to target system instead of
+# local system where ansible playbook was run from.
 keycloak_archive_on_target: false
+
+# Number of seconds to wait for Keycloak to start (default: 5 minutes)
+keycloak_startup_timeout: 300
+
+# Number of milliseconds to wait for jboss configuration utility
+# to connect to wildfly server (default: 5 seconds)
+keycloak_jboss_config_connect_timeout: 5000
+
+# Number of seconds to wait for jboss configuration utility
+# to complete each command executed in configuration file (default: 1 minute)
+keycloak_jboss_config_command_timeout: 60

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -20,9 +20,6 @@ provisioner:
     name: ansible-lint
 scenario:
   name: default
-  # This role is currently not idempotent, as we fail when a deployment
-  # aready exists.  We skip this test for now, though it would be a good idea
-  # to make the role idempotent.
   test_sequence:
     - lint
     - destroy
@@ -31,7 +28,7 @@ scenario:
     - create
     - prepare
     - converge
-    # - idempotence
+    - idempotence
     - side_effect
     - verify
     - destroy

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,32 @@
+[metadata]
+name = ansible-keycloak
+summary = Deploy Keycloak server
+description-file =
+    README.md
+author = Nathan Kinder
+author-email = nkinder.redhat.com
+home-page = https://github.com/nkinder/ansible-keycloak
+classifier =
+  License :: OSI Approved :: GNU General Public License v3 (GPLv3)
+  Development Status :: 4 - Beta
+  Intended Audience :: Developers
+  Intended Audience :: System Administrators
+  Intended Audience :: Information Technology
+  Topic :: Utilities
+
+[global]
+setup-hooks =
+    pbr.hooks.setup_hook
+
+[files]
+data_files =
+    usr/local/share/ansible/roles/ansible-keycloak/defaults = defaults/*
+    usr/local/share/ansible/roles/ansible-keycloak/files = files/*
+    usr/local/share/ansible/roles/ansible-keycloak/handlers = handlers/*
+    usr/local/share/ansible/roles/ansible-keycloak/meta = meta/*
+    usr/local/share/ansible/roles/ansible-keycloak/tasks = tasks/*
+    usr/local/share/ansible/roles/ansible-keycloak/templates = templates/*
+
+[pbr]
+skip_authors = True
+skip_changelog = True

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,19 @@
+#   Copyright Red Hat, Inc. All Rights Reserved.
+#
+#   Licensed under the Apache License, Version 2.0 (the "License"); you may
+#   not use this file except in compliance with the License. You may obtain
+#   a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#   WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#   License for the specific language governing permissions and limitations
+#   under the License.
+
+import setuptools
+
+setuptools.setup(
+    setup_requires=['pbr'],
+    pbr=True)

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,46 +1,5 @@
 ---
 
-- name: check if all required variables are set
-  fail: msg="The variable keycloak_admin_password must be explicitly set"
-  when: keycloak_admin_password is not defined
-
-- name: set the python interpreter to use on the target
-  import_tasks: "{{ role_path }}/tasks/python_2_3_test.yml"
-
-- name: create local download location
-  delegate_to: localhost
-  file:
-    dest: "{{ keycloak_local_download_dest }}"
-    state: directory
-  when: not keycloak_archive_on_target
-
-- name: install dependencies
-  package:
-    name: "{{ item }}"
-  loop:
-    - firewalld
-    - java-1.8.0-openjdk-headless
-    - unzip
-    - pyOpenSSL
-  become: yes
-
-- name: create Keycloak service user/group
-  user:
-    name: "{{ keycloak_service_user }}"
-    home: /
-    shell: /sbin/nologin
-    system: yes
-    create_home: no
-  become: yes
-
-- name: create Keycloak install location
-  file:
-    dest: "{{ keycloak_dest }}"
-    state: directory
-    owner: "{{ keycloak_service_user }}"
-    group: "{{ keycloak_service_group }}"
-  become: yes
-
 - name: check for an existing deployment
   stat:
     path: "{{ keycloak_jboss_home }}"
@@ -51,13 +10,6 @@
 # may have been made within Keycloak's database that would be lost.
 # A force variable can be set to overwrite the existing deployment.
 - block:
-    - name: check if we should force overwrite an existing deployment
-      fail:
-        msg: >-
-          Keycloak deployment already exists at {{ keycloak_jboss_home }}
-          (force=yes to overwrite)
-      when: (force is undefined) or
-            (force != "yes")
     - name: stop the old keycloak service
       systemd:
         name: keycloak
@@ -69,211 +21,268 @@
         path: "{{ keycloak_jboss_home }}"
         state: absent
       become: yes
-  when: existing_deploy.stat.exists
+  when: existing_deploy.stat.exists and keycloak_force|bool
 
-- block:
-    - name: download Keycloak archive to target
-      get_url:
-        url: "{{ keycloak_url }}"
-        dest: "{{ keycloak_dest }}"
-        owner: "{{ keycloak_service_user }}"
-        group: "{{ keycloak_service_group }}"
-    - name: extract Keycloak archive on target
-      unarchive:
-        remote_src: yes
-        src: "{{ keycloak_dest }}/{{ keycloak_url | basename }}"
-        dest: "{{ keycloak_dest }}"
-        creates: "{{ keycloak_jboss_home }}"
-        owner: "{{ keycloak_service_user }}"
-        group: "{{ keycloak_service_group }}"
+- name: check for an existing deployment after possible forced removal
+  stat:
+    path: "{{ keycloak_jboss_home }}"
+  register: existing_deploy
   become: yes
-  when: keycloak_archive_on_target
 
 - block:
-    - name: download Keycloak archive to local
+    - name: perform keycloak install
+      debug:
+        msg: performing keycloak install
+
+    - name: check if all required variables are set
+      fail: msg="The variable keycloak_admin_password must be explicitly set"
+      when: keycloak_admin_password is not defined
+
+    - name: set the python interpreter to use on the target
+      import_tasks: "{{ role_path }}/tasks/python_2_3_test.yml"
+
+    - name: create local download location
       delegate_to: localhost
-      get_url:
-        url: "{{ keycloak_url }}"
-        dest: "{{ keycloak_local_download_dest }}/{{ keycloak_archive }}"
-    - name: extract Keycloak archive on local
-      unarchive:
-        remote_src: no
-        src: "{{ keycloak_local_download_dest }}/{{ keycloak_url | basename }}"
+      file:
+        dest: "{{ keycloak_local_download_dest }}"
+        state: directory
+      when: not keycloak_archive_on_target
+
+    - name: install dependencies
+      package:
+        name: "{{ item }}"
+      loop:
+        - firewalld
+        - java-1.8.0-openjdk-headless
+        - unzip
+        - pyOpenSSL
+      become: yes
+
+    - name: create Keycloak service user/group
+      user:
+        name: "{{ keycloak_service_user }}"
+        home: /
+        shell: /sbin/nologin
+        system: yes
+        create_home: no
+      become: yes
+
+    - name: create Keycloak install location
+      file:
         dest: "{{ keycloak_dest }}"
-        creates: "{{ keycloak_jboss_home }}"
+        state: directory
         owner: "{{ keycloak_service_user }}"
         group: "{{ keycloak_service_group }}"
       become: yes
-  when: not keycloak_archive_on_target
 
-- name: create Keycloak admin user
-  command:
-  args:
-    argv:
-      - "{{ keycloak_jboss_home }}/bin/add-user-keycloak.sh"
-      - -r master
-      - -u {{ keycloak_admin_user }}
-      - -p {{ keycloak_admin_password }}
-    creates: "{{ keycloak_config_dir }}/keycloak-add-user.json"
-  become: yes
-  tags:
-    - skip_ansible_lint
+    - block:
+        - name: download Keycloak archive to target
+          get_url:
+            url: "{{ keycloak_url }}"
+            dest: "{{ keycloak_dest }}"
+            owner: "{{ keycloak_service_user }}"
+            group: "{{ keycloak_service_group }}"
+        - name: extract Keycloak archive on target
+          unarchive:
+            remote_src: yes
+            src: "{{ keycloak_dest }}/{{ keycloak_archive }}"
+            dest: "{{ keycloak_dest }}"
+            creates: "{{ keycloak_jboss_home }}"
+            owner: "{{ keycloak_service_user }}"
+            group: "{{ keycloak_service_group }}"
+      become: yes
+      when: keycloak_archive_on_target
 
-- name: validate and set PKCS12 variables
-  block:
-    - name: Check if the variables are set
-      fail:
-        msg: keycloak_tls_pkcs12 requires keycloak_tls_pkcs12_alias
-      when:
-        - keycloak_tls_pkcs12 is defined
-        - keycloak_tls_pkcs12_alias is not defined
-    - name: Set the PKCS12 alias
-      set_fact: keycloak_tls_pkcs12_alias="ansible-keycloak-server"
-      when:
-        - keycloak_tls_pkcs12 is not defined
-    - name: Set the PKCS12 passphrase
-      set_fact:
-        keycloak_tls_pkcs12_passphrase: >-
-            "{{
-                keycloak_tls_pkcs12_passphrase|default(keycloak_admin_password)
-             }}"
+    - block:
+        - name: download Keycloak archive to local
+          delegate_to: localhost
+          get_url:
+            url: "{{ keycloak_url }}"
+            dest: "{{ keycloak_local_download_dest }}/{{ keycloak_archive }}"
+        - name: extract Keycloak archive on local
+          unarchive:
+            remote_src: no
+            src: "{{ keycloak_local_download_dest }}/{{ keycloak_archive }}"
+            dest: "{{ keycloak_dest }}"
+            creates: "{{ keycloak_jboss_home }}"
+            owner: "{{ keycloak_service_user }}"
+            group: "{{ keycloak_service_group }}"
+          become: yes
+      when: not keycloak_archive_on_target
 
-- name: Allow Keycloak to generate it's own self-signed cert.
-  debug:
-    msg: >-
-      Keycloak will generate it's own self-signed cert.
-      It will not have the correct hostname nor a SAN.
-  when:
-    - keycloak_tls_key is not defined
-    - keycloak_tls_cert is not defined
-    - keycloak_tls_pkcs12 is not defined
-
-- block:
-    - name: copy key to PKCS12 location
-      copy:
-        src: "{{ keycloak_tls_key }}"
-        dest: "{{ keycloak_config_dir }}/tls-key.pem"
-    - name: copy cert to PKCS12 location
-      copy:
-        src: "{{ keycloak_tls_cert }}"
-        dest: "{{ keycloak_config_dir }}/tls-cert.pem"
-    - name: generate PKCS12
-      openssl_pkcs12:
-        action: export
-        force: yes
-        path: "{{ keycloak_config_dir }}/{{ keycloak_keystore_name }}"
-        passphrase: "{{ keycloak_tls_pkcs12_passphrase }}"
-        friendly_name: "{{ keycloak_tls_pkcs12_alias }}"
-        privatekey_path: "{{ keycloak_config_dir }}/tls-key.pem"
-        certificate_path: "{{ keycloak_config_dir }}/tls-cert.pem"
-        owner: "{{ keycloak_service_user }}"
-        group: "{{ keycloak_service_group }}"
-      register: keycloak_generated_pkcs12_bundle
-    - name: remove key from PKCS12 location
-      file:
-        path: "{{ keycloak_config_dir }}/tls-key.pem"
-        state: absent
-    - name: remove cert from PKCS12 location
-      file:
-        path: "{{ keycloak_config_dir }}/tls-cert.pem"
-        state: absent
-  become: yes
-  when:
-    - keycloak_tls_key is defined
-    - keycloak_tls_cert is defined
-    - keycloak_tls_pkcs12 is not defined
-
-- name: copy user provided PKCS12 bundle to server host
-  copy:
-    src: "{{ keycloak_tls_pkcs12 }}"
-    dest: "{{ keycloak_config_dir }}/{{ keycloak_keystore_name }}"
-    owner: "{{ keycloak_service_user }}"
-    group: "{{ keycloak_service_group }}"
-  become: yes
-  when:
-    - keycloak_tls_key is not defined
-    - keycloak_tls_cert is not defined
-    - keycloak_tls_pkcs12 is defined
-
-- name: enable and start the firewalld service
-  systemd:
-    name: firewalld
-    enabled: yes
-    state: started
-  become: yes
-
-- name: configure firewall for Keycloak ports
-  firewalld:
-    port: "{{ item }}"
-    permanent: true
-    state: enabled
-    immediate: yes
-  with_items:
-    - "{{ keycloak_http_port }}/tcp"
-    - "{{ keycloak_https_port }}/tcp"
-  become: yes
-
-- name: configure sysconfig file for keycloak service
-  template:
-    src: keycloak-sysconfig.j2
-    dest: /etc/sysconfig/keycloak
-    owner: root
-    group: root
-    mode: 0644
-  become: yes
-  notify:
-    - restart keycloak
-
-- name: configure systemd unit file for keycloak service
-  template:
-    src: keycloak.service.j2
-    dest: /etc/systemd/system/keycloak.service
-    owner: root
-    group: root
-    mode: 0644
-  become: yes
-  notify:
-    - reload systemd
-    - restart keycloak
-
-# Force the handlers to run now, as keycloak needs to be running before
-# the next tasks are executed.
-- meta: flush_handlers
-
-# The jboss-cli.sh tool requires the management interface to be up,
-# so we wait until it is available.  The management interface comes
-# up in two stages, so we first need to wait for an answer on the port
-# and we still need a long timeout for the jboss-cli.sh tool to wait
-# for internal first-boot initialization to complete.  We must finally
-# restart the keycloak service for our changes to take effect.
-- name: enable TLS in Keycloak server configuration file
-  block:
-    - name: wait for Keycloak management interface to be available
-      wait_for:
-        port: 9990
-    - name: create jboss-cli.sh command file
-      template:
-        src: standalone-tls-config.cli.j2
-        dest: "{{ keycloak_config_dir }}/standalone-tls-config.cli"
-        owner: root
-        group: root
-        mode: 0600
-    - name: apply keycloak TLS configuration
+    - name: create Keycloak admin user
       command:
       args:
         argv:
-          - "{{ keycloak_jboss_home }}/bin/jboss-cli.sh"
-          - --connect
-          - --timeout=30000
-          - --file={{ keycloak_config_dir }}/standalone-tls-config.cli
-      notify:
-        - restart keycloak
+          - "{{ keycloak_jboss_home }}/bin/add-user-keycloak.sh"
+          - -r master
+          - -u {{ keycloak_admin_user }}
+          - -p {{ keycloak_admin_password }}
+        creates: "{{ keycloak_config_dir }}/keycloak-add-user.json"
+      become: yes
       tags:
         - skip_ansible_lint
-    - name: clean up jboss-cli-sh command file
-      file:
-        path: "{{ keycloak_config_dir }}/standalone-tls-config.cli"
-        state: absent
-  become: yes
-  when: (keycloak_tls_pkcs12 is defined) or
-        (keycloak_generated_pkcs12_bundle is changed)
+
+    - name: validate and set PKCS12 variables
+      block:
+        - name: Check if the variables are set
+          fail:
+            msg: keycloak_tls_pkcs12 requires keycloak_tls_pkcs12_alias
+          when:
+            - keycloak_tls_pkcs12 is defined
+            - keycloak_tls_pkcs12_alias is not defined
+        - name: Set the PKCS12 alias
+          set_fact: keycloak_tls_pkcs12_alias="ansible-keycloak-server"
+          when:
+            - keycloak_tls_pkcs12 is not defined
+        - name: Set the PKCS12 passphrase
+          set_fact:
+            keycloak_tls_pkcs12_passphrase: >-
+                {{ keycloak_tls_pkcs12_passphrase |
+                   default(keycloak_admin_password) }}
+
+    - name: Allow Keycloak to generate it's own self-signed cert.
+      debug:
+        msg: >-
+          Keycloak will generate it's own self-signed cert.
+          It will not have the correct hostname nor a SAN.
+      when:
+        - keycloak_tls_key is not defined
+        - keycloak_tls_cert is not defined
+        - keycloak_tls_pkcs12 is not defined
+
+    - block:
+        - name: copy key to PKCS12 location
+          copy:
+            remote_src: "{{ keycloak_tls_files_on_target }}"
+            src: "{{ keycloak_tls_key }}"
+            dest: "{{ keycloak_config_dir }}/tls-key.pem"
+        - name: copy cert to PKCS12 location
+          copy:
+            remote_src: "{{ keycloak_tls_files_on_target }}"
+            src: "{{ keycloak_tls_cert }}"
+            dest: "{{ keycloak_config_dir }}/tls-cert.pem"
+        - name: generate PKCS12
+          openssl_pkcs12:
+            action: export
+            force: yes
+            path: "{{ keycloak_config_dir }}/{{ keycloak_keystore_name }}"
+            passphrase: "{{ keycloak_tls_pkcs12_passphrase }}"
+            friendly_name: "{{ keycloak_tls_pkcs12_alias }}"
+            privatekey_path: "{{ keycloak_config_dir }}/tls-key.pem"
+            certificate_path: "{{ keycloak_config_dir }}/tls-cert.pem"
+            owner: "{{ keycloak_service_user }}"
+            group: "{{ keycloak_service_group }}"
+          register: keycloak_generated_pkcs12_bundle
+        - name: remove key from PKCS12 location
+          file:
+            path: "{{ keycloak_config_dir }}/tls-key.pem"
+            state: absent
+        - name: remove cert from PKCS12 location
+          file:
+            path: "{{ keycloak_config_dir }}/tls-cert.pem"
+            state: absent
+      become: yes
+      when:
+        - keycloak_tls_key is defined
+        - keycloak_tls_cert is defined
+        - keycloak_tls_pkcs12 is not defined
+
+    - name: copy user provided PKCS12 bundle to server host
+      copy:
+        remote_src: "{{ keycloak_tls_files_on_target }}"
+        src: "{{ keycloak_tls_pkcs12 }}"
+        dest: "{{ keycloak_config_dir }}/{{ keycloak_keystore_name }}"
+        owner: "{{ keycloak_service_user }}"
+        group: "{{ keycloak_service_group }}"
+      become: yes
+      when:
+        - keycloak_tls_key is not defined
+        - keycloak_tls_cert is not defined
+        - keycloak_tls_pkcs12 is defined
+
+    - name: enable and start the firewalld service
+      systemd:
+        name: firewalld
+        enabled: yes
+        state: started
+      become: yes
+
+    - name: configure firewall for Keycloak ports
+      firewalld:
+        port: "{{ item }}"
+        permanent: true
+        state: enabled
+        immediate: yes
+      with_items:
+        - "{{ keycloak_http_port }}/tcp"
+        - "{{ keycloak_https_port }}/tcp"
+      become: yes
+
+    - name: configure sysconfig file for keycloak service
+      template:
+        src: keycloak-sysconfig.j2
+        dest: /etc/sysconfig/keycloak
+        owner: root
+        group: root
+        mode: 0644
+      become: yes
+      notify:
+        - restart keycloak
+
+    - name: configure systemd unit file for keycloak service
+      template:
+        src: keycloak.service.j2
+        dest: /etc/systemd/system/keycloak.service
+        owner: root
+        group: root
+        mode: 0644
+      become: yes
+      notify:
+        - reload systemd
+        - restart keycloak
+
+    # Force the handlers to run now, as keycloak needs to be running before
+    # the next tasks are executed.
+    - meta: flush_handlers
+
+    # The jboss-cli.sh tool requires the management interface to be up,
+    # so we wait until it is available.  The management interface comes
+    # up in two stages, so we first need to wait for an answer on the port
+    # and we still need a long timeout for the jboss-cli.sh tool to wait
+    # for internal first-boot initialization to complete.  We must finally
+    # restart the keycloak service for our changes to take effect.
+    - name: enable TLS in Keycloak server configuration file
+      block:
+        - name: wait for Keycloak management interface to be available
+          wait_for:
+            port: "{{ keycloak_management_http_port }}"
+            timeout: "{{ keycloak_startup_timeout }}"
+        - name: create jboss-cli.sh command file
+          template:
+            src: standalone-tls-config.cli.j2
+            dest: "{{ keycloak_config_dir }}/standalone-tls-config.cli"
+            owner: root
+            group: root
+            mode: 0600
+        - name: apply keycloak TLS configuration
+          command:
+          args:
+            argv:
+              - "{{ keycloak_jboss_home }}/bin/jboss-cli.sh"
+              - --connect
+              - --timeout={{ keycloak_jboss_config_connect_timeout }}
+              - --command-timeout={{ keycloak_jboss_config_command_timeout }}
+              - --file={{ keycloak_config_dir }}/standalone-tls-config.cli
+          notify:
+            - restart keycloak
+          tags:
+            - skip_ansible_lint
+        - name: clean up jboss-cli-sh command file
+          file:
+            path: "{{ keycloak_config_dir }}/standalone-tls-config.cli"
+            state: absent
+      become: yes
+      when: (keycloak_tls_pkcs12 is defined) or
+            (keycloak_generated_pkcs12_bundle is changed)
+  when: not existing_deploy.stat.exists

--- a/templates/keycloak-sysconfig.j2
+++ b/templates/keycloak-sysconfig.j2
@@ -3,3 +3,5 @@ JBOSS_HOME={{ keycloak_jboss_home }}
 KEYCLOAK_BIND_ADDRESS={{ keycloak_bind_address }}
 KEYCLOAK_HTTP_PORT={{ keycloak_http_port }}
 KEYCLOAK_HTTPS_PORT={{ keycloak_https_port }}
+KEYCLOAK_MANAGEMENT_HTTP_PORT={{ keycloak_management_http_port }}
+KEYCLOAK_MANAGEMENT_HTTPS_PORT={{ keycloak_management_https_port }}

--- a/templates/keycloak.service.j2
+++ b/templates/keycloak.service.j2
@@ -8,7 +8,7 @@ EnvironmentFile=/etc/sysconfig/keycloak
 
 User={{ keycloak_service_user }}
 Group={{ keycloak_service_group }}
-ExecStart={{ keycloak_jboss_home }}/bin/standalone.sh -Djboss.bind.address=${KEYCLOAK_BIND_ADDRESS} -Djboss.http.port=${KEYCLOAK_HTTP_PORT} -Djboss.https.port=${KEYCLOAK_HTTPS_PORT}
+ExecStart={{ keycloak_jboss_home }}/bin/standalone.sh -Djboss.bind.address=${KEYCLOAK_BIND_ADDRESS} -Djboss.http.port=${KEYCLOAK_HTTP_PORT} -Djboss.https.port=${KEYCLOAK_HTTPS_PORT} -Djboss.management.http.port=${KEYCLOAK_MANAGEMENT_HTTP_PORT} -Djboss.management.https.port=${KEYCLOAK_MANAGEMENT_HTTPS_PORT}
 TimeoutStartSec=600
 TimeoutStopSec=600
 


### PR DESCRIPTION
This patch rolls up all the modifications needed to be able to invoke
the ansible-keycloak role from tripleo-quickstart-extras. It includes
the following:

* Add configuration variable 'keycloak_tls_files_on_target'. This
  controls whether the source tls files are on the local controller
  node or on the remote target node. This was necessary to permit
  using IPA/certmonger to generate the cert/key pair which occurs on
  the remote target node.

* Add 'keycloak_management_http_port' and
  'keycloak_management_https_port` configuration variables and update
  the keycloak.service.j2 template file to utilize them. This was
  necessary because it was observed keycloak had a number of port
  conflicts with ports used by IPA. Previously these ports were
  hardcoded, now all ports used by Keycloak can be configured, this
  should alevate any problems with potential port conflicts.

* ansible-keycloak was not idempotent, if it detected Keycloak was
  already installed it would generate an error and the playbook would
  immediately fail. This behavior could be overridden by defining a
  variable called 'force'. The 'force' variable had two problems,
  first is that it was never defined in the defaults, second it was
  too generic and not namespaced to keycloak.

  - add 'keycloak_force' variable, default to false

  - refactor tasks/main to skip most of it's tasks if Keycloak was
    already installed unless 'keycloak_force' is true, in which case
    the exisiting deployment is removed and then the task list
    proceeds as if this were a new install.

* timeouts were occurring because of slow oooq virtual hosts, the
  following configuration timeout variables were added:

  - keycloak_startup_timeout
  - keycloak_jboss_config_connect_timeout
  - keycloak_jboss_config_command_timeout

* add Python setup configuration files 'setup.py' and
  'setup.cfg'. tripleo-quickstart depends on Python pip to install the
  files associated with a role. pip invokes setup.py with the
  'install' command. Although there are no Python files to be
  installed tripleo-quickstart takes advantage of Python's setuptools
  support to install data files (e.g. the role files).

Signed-off-by: John Dennis <jdennis@redhat.com>