### PR TITLE
Rename keycloak_force variable to keycloak_force_install

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ database.  A force variable can be set to overwrite the existing deployment.
 This can be either be set as a variable in the playbook, or added on the
 command line as an extra-var:
 
-  `ansible-playbook ... --extra-vars "keycloak_force=yes"`
+  `ansible-playbook ... --extra-vars "keycloak_force_install=yes"`
 
 Controlling the location of the Keycloak archive
 ------------------------------------------------

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -30,7 +30,7 @@ keycloak_tls_files_on_target: false
 ### Optional Behavior
 
 # If Keycloak is already installed remove it and re-install
-keycloak_force: false
+keycloak_force_install: false
 
 # Download Keycloak distribution to target system instead of
 # local system where ansible playbook was run from.

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -21,7 +21,7 @@
         path: "{{ keycloak_jboss_home }}"
         state: absent
       become: yes
-  when: existing_deploy.stat.exists and keycloak_force|bool
+  when: existing_deploy.stat.exists and keycloak_force_install|bool
 
 - name: check for an existing deployment after possible forced removal
   stat:


### PR DESCRIPTION
Review comments requested the force variable to be more explicit as to
what is being forced, hence keycloak_force becomes
keycloak_force_install.

Signed-off-by: John Dennis <jdennis@redhat.com>