### PR TITLE
Allow firewall configuration to be optionally skipped

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -46,3 +46,6 @@ keycloak_jboss_config_connect_timeout: 5000
 # Number of seconds to wait for jboss configuration utility
 # to complete each command executed in configuration file (default: 1 minute)
 keycloak_jboss_config_command_timeout: 60
+
+# Configure the firewall to allow access to Keycloak public ports
+keycloak_configure_firewall: true

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -52,7 +52,6 @@
       package:
         name: "{{ item }}"
       loop:
-        - firewalld
         - java-1.8.0-openjdk-headless
         - unzip
         - pyOpenSSL
@@ -201,12 +200,21 @@
         - keycloak_tls_cert is not defined
         - keycloak_tls_pkcs12 is defined
 
+    - name: install firewalld
+      package:
+        name: firewalld
+      become: yes
+      when:
+        - keycloak_configure_firewall
+
     - name: enable and start the firewalld service
       systemd:
         name: firewalld
         enabled: yes
         state: started
       become: yes
+      when:
+        - keycloak_configure_firewall
 
     - name: configure firewall for Keycloak ports
       firewalld:
@@ -218,6 +226,8 @@
         - "{{ keycloak_http_port }}/tcp"
         - "{{ keycloak_https_port }}/tcp"
       become: yes
+      when:
+        - keycloak_configure_firewall
 
     - name: configure sysconfig file for keycloak service
       template:


### PR DESCRIPTION
In some cases, one might want to skip having the role configure
the firewall.  For example, if the firewall is already disabled
and other network services are running on the system, having this
role enable and configure the firewall will result in non-keycloak
ports being blocked.

This adds a new optional parameter to skip firewall configuration.
The default behavior is to configure the firewall, which retains
the previous behavior for backwards compatibility.