### PR TITLE
Workaround for https://github.com/ansible/molecule/issues/1727

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,9 @@ env:
 install:
   # Install test dependencies.
   - pip install -r test-requirements.txt
+  # workaround until https://github.com/ansible/molecule/issues/1727 is fixed
+  - pip uninstall -y testinfra
+  - pip install testinfra
 
 before_script:
   # Use actual Ansible Galaxy role name for the project directory.


### PR DESCRIPTION
This works around an issue with ansible and molecule that breaks
our CI.  This issue was recently fixed upstream, but is not yet
available in the packages used during testing.