### PR TITLE
Added ability to add proxy configuration to keycloak

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -52,3 +52,11 @@ keycloak_configure_firewall: true
 
 # Configure the JAVA_OPTS used by the Keycloak service
 keycloak_java_opts: "-Xms1024m -Xmx20480m -XX:MaxPermSize=768m"
+
+# Enable proxy address forwarding in the http handler
+keycloak_revproxy_forwarding: false
+
+# Enable HTTPs rewriting (used if HTTPs is terminated by the reverse proxy and not by keycloak itself)
+# Only used if there is proxy address forwarding configured
+keycloak_revproxy_https: false
+keycloak_revproxy_https_port: 443

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -56,7 +56,8 @@ keycloak_java_opts: "-Xms1024m -Xmx20480m -XX:MaxPermSize=768m"
 # Enable proxy address forwarding in the http handler
 keycloak_revproxy_forwarding: false
 
-# Enable HTTPs rewriting (used if HTTPs is terminated by the reverse proxy and not by keycloak itself)
+# Enable HTTPs rewriting (used if HTTPs is terminated 
+# by the reverse proxy and not by keycloak itself)
 # Only used if there is proxy address forwarding configured
 keycloak_revproxy_https: false
 keycloak_revproxy_https_port: 443

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -56,7 +56,7 @@ keycloak_java_opts: "-Xms1024m -Xmx20480m -XX:MaxPermSize=768m"
 # Enable proxy address forwarding in the http handler
 keycloak_revproxy_forwarding: false
 
-# Enable HTTPs rewriting (used if HTTPs is terminated 
+# Enable HTTPs rewriting (used if HTTPs is terminated
 # by the reverse proxy and not by keycloak itself)
 # Only used if there is proxy address forwarding configured
 keycloak_revproxy_https: false

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -299,4 +299,72 @@
       become: yes
       when: (keycloak_tls_pkcs12 is defined) or
             (keycloak_generated_pkcs12_bundle is changed)
+    
+    # This part enables both the proxy and https reverse proxy
+    # 
+    # The jboss-cli.sh tool requires the management interface to be up,
+    # so we wait until it is available.  The management interface comes
+    # up in two stages, so we first need to wait for an answer on the port
+    # and we still need a long timeout for the jboss-cli.sh tool to wait
+    # for internal first-boot initialization to complete.  We must finally
+    # restart the keycloak service for our changes to take effect.
+    - name: Enable Keycloak Reverse Proxy Settings
+      block:
+        - name: wait for Keycloak management interface to be available
+          wait_for:
+            port: "{{ keycloak_management_http_port }}"
+            timeout: "{{ keycloak_startup_timeout }}"
+        - name: create jboss-cli.sh command file for reverse proxy
+          template:
+            src: keycloak-proxy-fwd.cli.j2
+            dest: "{{ keycloak_config_dir }}/keycloak-proxy-fwd.cli"
+            owner: root
+            group: root
+            mode: 0600
+          when: keycloak_revproxy_forwarding|bool
+        - name: apply keycloak reverse proxy configuration
+          command:
+          args:
+            argv:
+              - "{{ keycloak_jboss_home }}/bin/jboss-cli.sh"
+              - --connect
+              - --timeout={{ keycloak_jboss_config_connect_timeout }}
+              - --command-timeout={{ keycloak_jboss_config_command_timeout }}
+              - --file={{ keycloak_config_dir }}/keycloak-proxy-fwd.cli
+          notify:
+            - restart keycloak
+          tags:
+            - skip_ansible_lint
+          when: keycloak_revproxy_forwarding|bool
+        
+        - name: create jboss-cli.sh command file for https reverse proxy
+          template:
+            src: keycloak-socket-binding.cli.j2
+            dest: "{{ keycloak_config_dir }}/keycloak-socket-binding.cli"
+            owner: root
+            group: root
+            mode: 0600
+          when: keycloak_revproxy_https|bool
+        - name: apply keycloak reverse https proxy configuration
+          command:
+          args:
+            argv:
+              - "{{ keycloak_jboss_home }}/bin/jboss-cli.sh"
+              - --connect
+              - --timeout={{ keycloak_jboss_config_connect_timeout }}
+              - --command-timeout={{ keycloak_jboss_config_command_timeout }}
+              - --file={{ keycloak_config_dir }}/keycloak-socket-binding.cli
+          notify:
+            - restart keycloak
+          tags:
+            - skip_ansible_lint
+          when: keycloak_revproxy_https|bool
+
+        - name: clean up jboss-cli-sh command file
+          file:
+            path: "{{ keycloak_config_dir }}/keycloak-proxy-fwd.cli"
+            state: absent
+      become: yes
+      when: keycloak_revproxy_forwarding|bool or keycloak_revproxy_https|bool
+
   when: not existing_deploy.stat.exists

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -299,9 +299,9 @@
       become: yes
       when: (keycloak_tls_pkcs12 is defined) or
             (keycloak_generated_pkcs12_bundle is changed)
-    
+
     # This part enables both the proxy and https reverse proxy
-    # 
+    #
     # The jboss-cli.sh tool requires the management interface to be up,
     # so we wait until it is available.  The management interface comes
     # up in two stages, so we first need to wait for an answer on the port
@@ -336,7 +336,7 @@
           tags:
             - skip_ansible_lint
           when: keycloak_revproxy_forwarding|bool
-        
+
         - name: create jboss-cli.sh command file for https reverse proxy
           template:
             src: keycloak-socket-binding.cli.j2

--- a/templates/keycloak-proxy-fwd.cli.j2
+++ b/templates/keycloak-proxy-fwd.cli.j2
@@ -1,0 +1,6 @@
+#  Enable https listener for the new security realm
+/subsystem=undertow/ \
+  server=default-server/ \
+    http-listener=default \
+      :write-attribute(name=proxy-address-forwarding, \
+                       value=true)

--- a/templates/keycloak-socket-binding.cli.j2
+++ b/templates/keycloak-socket-binding.cli.j2
@@ -1,0 +1,11 @@
+#  Create new socket binding with proxy https port
+/socket-binding-group=standard-sockets/ \
+  socket-binding=proxy-https \
+    :add(port={{ keycloak_revproxy_https_port }})
+
+#  Enable https listener for the new security realm
+/subsystem=undertow/ \
+  server=default-server/ \
+    http-listener=default \
+      :write-attribute(name=redirect-socket, \
+                       value="proxy-https")


### PR DESCRIPTION
Hi all,

I've added the ability to add proxy configurations (reverse proxy e.g. using Nginx) for both http and https configuration. I followed the configuration from the configuration guide and added the relevant configuration snippets.

https://www.keycloak.org/docs/latest/server_installation/index.html#_setting-up-a-load-balancer-or-proxy