### PR TITLE
install pyOpenSSL package more dynamically

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,8 +8,8 @@ env:
     - ROLE_NAME: nkinder.keycloak
   matrix:
     - MOLECULE_DISTRO="centos:7"
-    - MOLECULE_DISTRO="fedora:28"
-    - MOLECULE_DISTRO="fedora:29"
+    - MOLECULE_DISTRO="fedora:30"
+    - MOLECULE_DISTRO="fedora:31"
 
 install:
   # Install test dependencies.

--- a/molecule/default/Dockerfile.j2
+++ b/molecule/default/Dockerfile.j2
@@ -7,8 +7,27 @@ FROM {{ item.image }}
 {% endif %}
 
 RUN if [ $(command -v apt-get) ]; then apt-get update && apt-get install -y python sudo bash ca-certificates && apt-get clean; \
-    elif [ $(command -v dnf) ]; then dnf makecache && dnf --assumeyes install python sudo python-devel python2-dnf bash && dnf clean all; \
+    elif [ $(command -v dnf) ]; then dnf makecache && dnf --assumeyes install python sudo python-devel python3-dnf bash && dnf clean all; \
     elif [ $(command -v yum) ]; then yum makecache fast && yum install -y python sudo yum-plugin-ovl bash && sed -i 's/plugins=0/plugins=1/g' /etc/yum.conf && yum clean all; \
     elif [ $(command -v zypper) ]; then zypper refresh && zypper install -y python sudo bash python-xml && zypper clean -a; \
     elif [ $(command -v apk) ]; then apk update && apk add --no-cache python sudo bash ca-certificates; \
     elif [ $(command -v xbps-install) ]; then xbps-install -Syu && xbps-install -y python sudo bash ca-certificates && xbps-remove -O; fi
+
+# Workaround to avoid issue #22 with Travis CI test failures due to 
+# firewalld not seeing kernel modules
+# TODO: remove when fixes released for Centos and Fedora
+
+{% if item.image == "centos:7"
+   or item.image == "fedora:30"
+   or item.image == "fedora:31" %}
+
+RUN yum -y install kmod
+RUN yum -y install firewalld
+RUN export MODULES_DIR=/lib/modules/$(uname -r); \
+    mkdir -p ${MODULES_DIR}; \
+    /bin/truncate --size=0 ${MODULES_DIR}/modules.builtin; \
+    /bin/truncate --size=0 ${MODULES_DIR}/modules.order; \
+    for i in /sys/module/*; do echo kernel/${i##**/}.ko; done >> ${MODULES_DIR}/modules.builtin; \
+    if [ -f /usr/sbin/depmod ]; then depmod -a; fi;
+
+{% endif %}

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -54,7 +54,7 @@
       loop:
         - java-1.8.0-openjdk-headless
         - unzip
-        - pyOpenSSL
+        - "{{ keycloak_dep_pyOpenSSL }}"
       become: yes
 
     - name: create Keycloak service user/group

--- a/tasks/python_2_3_test.yml
+++ b/tasks/python_2_3_test.yml
@@ -8,9 +8,11 @@
 - name: Set python interpreter to 3
   set_fact:
     ansible_python_interpreter: "/usr/bin/python3"
+    keycloak_dep_pyOpenSSL: "python3-pyOpenSSL"
   when: py3test.rc == 0
 
 - name: Set python interpreter to 2
   set_fact:
     ansible_python_interpreter: "/usr/bin/python2"
+    keycloak_dep_pyOpenSSL: "pyOpenSSL"
   when: py3test.failed or py3test.rc != 0


### PR DESCRIPTION
RHEL8 cannot install the python3 version of pyOpenSSL with that name.
You must use "python3-pyOpenSSL" to install for RHEL8.

Adding a fact to python_2_3_test.yml to define which package name to
use for pyOpenSSL:  keycloak_dep_pyOpenSSL

Changing package install for dependencies to use the fact that we set
in the python_2_3_test.yml task.

Resolves: issue #24

https://github.com/nkinder/ansible-keycloak/issues/24