### PR TITLE
Conditional python version autodetection and task blocks

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -51,10 +51,11 @@
     - name: install dependencies
       package:
         name: "{{ item }}"
-      loop:
-        - java-1.8.0-openjdk-headless
-        - unzip
-        - pyOpenSSL
+      loop: '{{ deps + python_deps | default([]) }}'
+      vars:
+        deps:
+          - java-1.8.0-openjdk-headless
+          - unzip
       become: yes
 
     - name: create Keycloak service user/group

--- a/tasks/python_2_3_test.yml
+++ b/tasks/python_2_3_test.yml
@@ -28,12 +28,14 @@
 - name: Tasks for Python 2
   block:
     - set_fact:
-        keycloak_dep_pyOpenSSL: "pyOpenSSL"
+        python_deps:
+          - pyOpenSSL
   when: python_major_version == 2
 
 
 - name: Tasks for Python 3
   block:
     - set_fact:
-        keycloak_dep_pyOpenSSL: "python3-pyOpenSSL"
+        python_deps:
+          - python3-pyOpenSSL
   when: python_major_version == 3

--- a/tasks/python_2_3_test.yml
+++ b/tasks/python_2_3_test.yml
@@ -1,16 +1,39 @@
 ---
-- name: Verify Python3 import
-  script: py3test.py
-  register: py3test
-  failed_when: False
-  changed_when: False
-
-- name: Set python interpreter to 3
+- name: Get Python version when ansible_python_interpreter is defined
   set_fact:
-    ansible_python_interpreter: "/usr/bin/python3"
-  when: py3test.rc == 0
+    python_major_version: '{{ ansible_python_version[0:1] }}'
+  when: ansible_python_interpreter is defined
 
-- name: Set python interpreter to 2
-  set_fact:
-    ansible_python_interpreter: "/usr/bin/python2"
-  when: py3test.failed or py3test.rc != 0
+- name: Get Python version when ansible_python_interpreter is undefined
+  block:
+  - name: Verify Python3 import
+    script: py3test.py
+    register: py3test
+    failed_when: False
+    changed_when: False
+
+  - set_fact:
+      python_major_version: 3
+    when: py3test.rc == 0
+
+  - set_fact:
+      python_major_version: 2
+    when: py3test.failed or py3test.rc != 0
+
+  - set_fact:
+      ansible_python_interpreter: '/usr/bin/python{{ python_major_version }}'
+
+  when: ansible_python_interpreter is undefined
+
+- name: Tasks for Python 2
+  block:
+    - set_fact:
+        keycloak_dep_pyOpenSSL: "pyOpenSSL"
+  when: python_major_version == 2
+
+
+- name: Tasks for Python 3
+  block:
+    - set_fact:
+        keycloak_dep_pyOpenSSL: "python3-pyOpenSSL"
+  when: python_major_version == 3


### PR DESCRIPTION
There are two changes in this patch:

1- have the python autodetection via import to happen only when `ansible_python_interpreter` is undefined at the time of role application. Autodetection itself works exactly as before, setting `ansible_python_interpreter` according to the py3test.py test.

- When `ansible_python_interpreter` was previously set, assume it is the same interpreter whose current version is reported in `ansible_python_version`.

-  Whether autodetection is done or not, a dedicated variable `python_major_version` is set to either "2" or "3", and all operations that depend on the python version are done evaluating that variable. This includes setting `ansible_python_interpreter` when autodetected.

This change solves #28 

2- add the python dependencies in a list (currently there's only one anyway), so they are added deterministically to the processing loop at main.yml.

This change is optional and partially unrelated, so it can go in another PR or remain unmerged, it doesn't affect 1-.